### PR TITLE
Changed material for stars to whiten them

### DIFF
--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ scene.add(pointLight, ambientLight);
 
 function addStar() {
   const geometry = new THREE.SphereGeometry(0.25, 24, 24);
-  const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
   const star = new THREE.Mesh(geometry, material);
 
   const [x, y, z] = Array(3)


### PR DESCRIPTION
Changed material in function addStar() from MeshStandardMaterial to MeshBasicMaterial to prevent stars to be displayed gray instead of white.

See issue: https://github.com/fireship-io/threejs-scroll-animation-demo/issues/20